### PR TITLE
Enforce HTTP timeouts in PanAPI requests and add unit test

### DIFF
--- a/api/pan_api.py
+++ b/api/pan_api.py
@@ -172,7 +172,7 @@ class PanAPI:
         }
 
         try:
-            response = requests.post(url, headers=headers, json=body)
+            response = requests.post(url, headers=headers, json=body, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code == 200:
                 try:
@@ -271,7 +271,7 @@ class PanAPI:
         }
 
         try:
-            response = requests.post(url, headers=headers, json=body)
+            response = requests.post(url, headers=headers, json=body, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code == 200:
                 data = response.json()
@@ -324,7 +324,7 @@ class PanAPI:
         }
 
         try:
-            response = requests.post(url, headers=headers, json=body)
+            response = requests.post(url, headers=headers, json=body, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code == 200:
                 data = response.json()
@@ -377,7 +377,7 @@ class PanAPI:
         }
 
         try:
-            response = requests.get(url, headers=headers, params=params)
+            response = requests.get(url, headers=headers, params=params, timeout=DEFAULT_TIMEOUT)
 
             if response.status_code == 200:
                 data = response.json()

--- a/tests/test_request_timeouts.py
+++ b/tests/test_request_timeouts.py
@@ -1,0 +1,39 @@
+"""
+Tests for HTTP request timeout configuration.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+class TestRequestTimeouts(unittest.TestCase):
+    """Ensure outbound HTTP calls always include a timeout."""
+
+    def test_all_requests_calls_include_timeout(self):
+        source_path = Path(__file__).resolve().parents[1] / "api" / "pan_api.py"
+        tree = ast.parse(source_path.read_text(), filename=str(source_path))
+
+        calls_without_timeout = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr in {"get", "post"}
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "requests"
+            ):
+                continue
+
+            keyword_names = {keyword.arg for keyword in node.keywords}
+            if "timeout" not in keyword_names:
+                calls_without_timeout.append((func.attr, node.lineno))
+
+        self.assertEqual([], calls_without_timeout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure outbound HTTP calls in `PanAPI` include timeouts to prevent hanging and improve robustness.

### Description
- Added `timeout=DEFAULT_TIMEOUT` to the `requests.post` call in `ensure_token`.
- Added `timeout=DEFAULT_TIMEOUT` to the `requests.post` calls in `enable_direct_link` and `disable_direct_link`.
- Added `timeout=DEFAULT_TIMEOUT` to the `requests.get` call in `get_direct_link`.
- Added a new unit test `tests/test_request_timeouts.py` that verifies all `requests.get` and `requests.post` calls include a `timeout` keyword.

### Testing
- Ran the new unit test with `python -m unittest tests.test_request_timeouts` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff2b38481c8327bc138da1a1e66616)